### PR TITLE
기본 문자열 타입을 와이드 캐릭터로 변경하였음. 이에 따른 문자열 서식 수정을 동반함

### DIFF
--- a/Source/Core/Config/ConfigManager.cpp
+++ b/Source/Core/Config/ConfigManager.cpp
@@ -11,17 +11,17 @@ bool UConfigManager::LoadConfig(const FString& InConfigName)
 	// if (IsDebuggerPresent())
 	{
 		filesystem::path curPath = filesystem::current_path();
-		filesystem::path configPath = curPath / "Config" / InConfigName.GetData();
+		filesystem::path configPath = curPath / "Config" / InConfigName.c_char();
 		if (filesystem::exists(configPath) == false)
 		{
-			std::cout << "Config file not found!" << std::endl;
+			std::cout << "Config file not found!" << '\n';
 			return false;
 		}
 
 		ifstream configFile(configPath);
 		if (configFile.is_open() == false)
 		{
-			std::cout << "File open failed: " << configPath << std::endl;
+			std::cout << "File open failed: " << configPath << '\n';
 			return false;
 		}
 
@@ -72,13 +72,13 @@ bool UConfigManager::SaveConfig(const FString& InConfigName)
 	if (IsDebuggerPresent())
 	{
 		filesystem::path curPath = filesystem::current_path();
-		filesystem::path configPath = curPath / "Config" / InConfigName.GetData();
+		filesystem::path configPath = curPath / "Config" / InConfigName.c_char();
 		filesystem::path parentPath = configPath.parent_path();
 		if (parentPath.empty() == false && filesystem::exists(parentPath) == false)
 		{
 			if (filesystem::create_directories(parentPath) == false)
 			{
-				std::cout << "Failed to create directory: " << parentPath << std::endl;
+				std::cout << "Failed to create directory: " << parentPath << '\n';
 				return false;
 			}
 		}
@@ -86,19 +86,19 @@ bool UConfigManager::SaveConfig(const FString& InConfigName)
 		ofstream configFile(configPath);
 		if (configFile.is_open() == false)
 		{
-			std::cout << "File open failed: " << configPath << std::endl;
+			std::cout << "File open failed: " << configPath << '\n';
 			return false;
 		}
 
 		for (const auto& [section, keyValues] : Configs)
 		{
 			if (section.IsEmpty() == false)
-				configFile << "[" << section.GetData() << "]" << std::endl;
+				configFile << "[" << section.c_char() << "]" << '\n';
 			for (const auto& [key, value] : keyValues)
 			{
-				configFile << key.GetData() << " = " << value.GetData() << std::endl;
+				configFile << key.c_char() << " = " << value.c_char() << '\n';
 			}
-			configFile << std::endl;
+			configFile << '\n';
 		}
 
 		return true;

--- a/Source/Core/Container/CString.h
+++ b/Source/Core/Container/CString.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <cstring>
 #include <cwchar>
 #include <cctype>
@@ -14,11 +14,11 @@ public:
     {
         if constexpr (std::is_same_v<CharType, char>)
         {
-            return std::strcpy(dest, src);
+            return strcpy_s(dest, src);
         }
         else if constexpr (std::is_same_v<CharType, wchar_t>)
         {
-            return std::wcscpy(dest, src);
+            return wcscpy_s(dest, src);
         }
         else
         {
@@ -31,11 +31,11 @@ public:
     {
         if constexpr (std::is_same_v<CharType, char>)
         {
-            return std::strncpy(dest, src, count);
+            return strcpy_s(dest, src, count);
         }
         else if constexpr (std::is_same_v<CharType, wchar_t>)
         {
-            return std::wcsncpy(dest, src, count);
+            return wcscpy_s(dest, src, count);
         }
         else
         {
@@ -48,11 +48,11 @@ public:
     {
         if constexpr (std::is_same_v<CharType, char>)
         {
-            return std::strcat(dest, src);
+            return strcat_s(dest, src);
         }
         else if constexpr (std::is_same_v<CharType, wchar_t>)
         {
-            return std::wcscat(dest, src);
+            return wcscat_s(dest, src);
         }
         else
         {

--- a/Source/Core/Container/String.h
+++ b/Source/Core/Container/String.h
@@ -22,31 +22,34 @@ enum : int8 { INDEX_NONE = -1 };
 /** Determines case sensitivity options for string comparisons. */
 namespace ESearchCase
 {
-enum Type : uint8
-{
-    /** Case sensitive. Upper/lower casing must match for strings to be considered equal. */
-    CaseSensitive,
+	enum Type : uint8
+	{
+	    /** Case sensitive. Upper/lower casing must match for strings to be considered equal. */
+	    CaseSensitive,
 
-    /** Ignore case. Upper/lower casing does not matter when making a comparison. */
-    IgnoreCase,
-};
+	    /** Ignore case. Upper/lower casing does not matter when making a comparison. */
+	    IgnoreCase,
+	};
 };
 
 /** Determines search direction for string operations. */
 namespace ESearchDir
 {
-enum Type : uint8
-{
-    /** Search from the start, moving forward through the string. */
-    FromStart,
+	enum Type : uint8
+	{
+	    /** Search from the start, moving forward through the string. */
+	    FromStart,
 
-    /** Search from the end, moving backward through the string. */
-    FromEnd,
-};
+	    /** Search from the end, moving backward through the string. */
+	    FromEnd,
+	};
 }
 
 class FString
 {
+public:
+	static const size_t npos = -1;
+
 private:
 	using ElementType = TCHAR;
     using BaseStringType = std::basic_string<
@@ -70,10 +73,13 @@ public:
 
     FString(BaseStringType InString) : PrivateString(std::move(InString)) {}
 
-#if USE_WIDECHAR
 private:
-    static std::wstring ConvertToWideChar(const ANSICHAR* NarrowStr);
+	// WIDECHAR 사용처에서 사용할 수 있도록
+	static std::wstring ConvertToWideChar(const ANSICHAR* NarrowStr);
+	// ANSICHAR 사용처에서 사용할 수 있도록
+	static std::string ConvertToMultibyte(const WIDECHAR* WideStr);
 
+#if USE_WIDECHAR
 public:
     FString(const std::wstring& InString) : PrivateString(InString) {}
     FString(const std::string& InString) : PrivateString(ConvertToWideChar(InString.c_str())) {}
@@ -85,45 +91,51 @@ public:
     FString(const ANSICHAR* InString) : PrivateString(InString) {}
 #endif
 
-#if USE_WIDECHAR
-	FORCEINLINE std::string ToAnsiString() const
-	{
-		// Wide 문자열을 UTF-8 기반의 narrow 문자열로 변환
-		if (PrivateString.empty())
-		{
-			return std::string();
-		}
-		int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, PrivateString.c_str(), -1, nullptr, 0, nullptr, nullptr);
-		if (sizeNeeded <= 0)
-		{
-			return std::string();
-		}
-		std::string result(sizeNeeded, 0);
-		WideCharToMultiByte(CP_UTF8, 0, PrivateString.c_str(), -1, &result[0], sizeNeeded, nullptr, nullptr);
-		return result;
-	}
-#else
-	FORCEINLINE std::wstring ToWideString() const
-	{
-#if USE_WIDECHAR
-		return PrivateString;
-#else
-		// Narrow 문자열을 UTF-8로 가정하고 wide 문자열로 변환
-		if (PrivateString.empty())
-		{
-			return std::wstring();
-		}
-		int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, PrivateString.c_str(), -1, nullptr, 0);
-		if (sizeNeeded <= 0)
-		{
-			return std::wstring();
-		}
-		std::wstring wstr(sizeNeeded, 0);
-		MultiByteToWideChar(CP_UTF8, 0, PrivateString.c_str(), -1, &wstr[0], sizeNeeded);
-		return wstr;
-#endif
-	}
-#endif
+	// 반드시 const char*를 반환하는 함수
+	FORCEINLINE const char* c_char() const;
+	FORCEINLINE const wchar_t* c_wchar() const;
+
+	/** Use c_char() or c_wchar() instead. */
+//#if USE_WIDECHAR
+//	FORCEINLINE std::string ToAnsiString() const
+//	{
+//		// Wide 문자열을 UTF-8 기반의 narrow 문자열로 변환
+//		if (PrivateString.empty())
+//		{
+//			return std::string();
+//		}
+//		int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, PrivateString.c_str(), -1, nullptr, 0, nullptr, nullptr);
+//		if (sizeNeeded <= 0)
+//		{
+//			return std::string();
+//		}
+//		std::string result(sizeNeeded, 0);
+//		WideCharToMultiByte(CP_UTF8, 0, PrivateString.c_str(), -1, &result[0], sizeNeeded, nullptr, nullptr);
+//		return result;
+//	}
+//#else
+//	FORCEINLINE std::wstring ToWideString() const
+//	{
+//#if USE_WIDECHAR
+//		return PrivateString;
+//#else
+//		// Narrow 문자열을 UTF-8로 가정하고 wide 문자열로 변환
+//		if (PrivateString.empty())
+//		{
+//			return std::wstring();
+//		}
+//		int sizeNeeded = MultiByteToWideChar(CP_UTF8, 0, PrivateString.c_str(), -1, nullptr, 0);
+//		if (sizeNeeded <= 0)
+//		{
+//			return std::wstring();
+//		}
+//		std::wstring wstr(sizeNeeded, 0);
+//		MultiByteToWideChar(CP_UTF8, 0, PrivateString.c_str(), -1, &wstr[0], sizeNeeded);
+//		return wstr;
+//#endif
+//	}
+//#endif
+
 	template <typename Number>
 		requires std::is_arithmetic_v<Number>
     static FString FromInt(Number Num);
@@ -131,6 +143,9 @@ public:
     static FString SanitizeFloat(float InFloat);
 
 	static float ToFloat(const FString& InString);
+
+	// findlastof
+	FORCEINLINE size_t FindLastOf(const ElementType* Char) const;
 
 public:
     FORCEINLINE int32 Len() const;
@@ -172,6 +187,47 @@ public:
         ESearchDir::Type SearchDir = ESearchDir::FromStart, int32 StartPosition = -1
     ) const;
 
+	/**
+	 * 대소문자 구분 없이 문자열을 지정된 길이만큼 비교합니다.
+	 * @param Other 비교할 String
+	 * @param Count 비교할 길이
+	 * @return 비교 결과
+	 */
+	int Strnicmp(const FString& Other, const size_t Count) const;
+
+	/**
+	 * 문자열의 n번째 이후의 부분 문자열을 반환합니다.
+	 * @param Pos 시작 위치
+	 * @param Count 길이 (기본값: npos)
+	 * @return 부분 문자열
+	 */
+	FString Substr(const size_t Pos, const size_t Count = npos) const;
+
+	void RemoveAt(int32 Index, int32 Count, bool bAllowShrinking);
+
+	/** 문자열의 첫 번째 문자를 반환합니다. */
+	FORCEINLINE ElementType& Front();
+	FORCEINLINE const ElementType& Front() const;
+
+	/** 문자열의 마지막 문자를 반환합니다. */
+	FORCEINLINE ElementType& Back();
+	FORCEINLINE const ElementType& Back() const;
+
+	/** 문자열의 마지막 문자를 제거합니다. */
+	void PopBack();
+
+	/** 문자열의 지정된 위치에서 지정된 길이만큼 제거합니다. */
+	void RemoveAt(const size_t Pos, const size_t Count = npos);
+	void RemoveAt(BaseStringType::iterator It, const size_t Count = npos);
+
+	/** 문자열의 시작 반복자를 반환합니다. */
+	FORCEINLINE BaseStringType::iterator Begin();
+	FORCEINLINE BaseStringType::const_iterator Begin() const;
+
+	/** 문자열을 대문자로 변환합니다. */
+	FString ToUpper() const;
+
+
 	const FString::ElementType* GetData() const;
 
 public:
@@ -179,11 +235,18 @@ public:
     FORCEINLINE const ElementType* operator*() const;
 
     // FORCEINLINE FString operator+(const FString& SubStr) const;
-    FORCEINLINE FString& operator+=(const FString& SubStr);
-    FORCEINLINE friend FString operator+(const FString& Lhs, const FString& Rhs);
+	FORCEINLINE FString& operator+=(const FString& SubStr);
+	FORCEINLINE FString& operator+=(const ElementType* Rhs);
+	FORCEINLINE FString operator+(const FString& SubStr);
+	FORCEINLINE FString operator+(const ElementType* Rhs);
+	FORCEINLINE friend FString operator+(const FString& Lhs, const FString& Rhs);
 
     FORCEINLINE bool operator==(const FString& Rhs) const;
     FORCEINLINE bool operator==(const ElementType* Rhs) const;
+
+	/** n번째 위치의 문자를 가져오는 연산자 오버로딩 */
+	FORCEINLINE ElementType& operator[](const size_t Index);
+	FORCEINLINE const ElementType& operator[](const size_t Index) const;
 };
 
 template <typename Number>
@@ -195,6 +258,11 @@ FString FString::FromInt(Number Num)
 #else
     return FString{std::to_string(Num)};
 #endif
+}
+
+inline size_t FString::FindLastOf(const ElementType* Char) const
+{
+	return PrivateString.find_last_of(Char);
 }
 
 FORCEINLINE int32 FString::Len() const
@@ -212,15 +280,20 @@ FORCEINLINE const FString::ElementType* FString::operator*() const
     return PrivateString.c_str();
 }
 
-// FORCEINLINE FString FString::operator+(const FString& SubStr) const
-// {
-//     return this->PrivateString + SubStr.PrivateString;
-// }
+FORCEINLINE FString FString::operator+(const FString& SubStr)
+{
+	return this->PrivateString + SubStr.PrivateString;
+}
+
+inline FString FString::operator+(const ElementType* Rhs)
+{
+	return this->PrivateString + Rhs;
+}
 
 FString operator+(const FString& Lhs, const FString& Rhs)
 {
-    FString CopyLhs{Lhs};
-    return CopyLhs += Rhs;
+	FString CopyLhs{ Lhs };
+	return CopyLhs += Rhs;
 }
 
 FORCEINLINE bool FString::operator==(const FString& Rhs) const
@@ -237,6 +310,79 @@ FORCEINLINE FString& FString::operator+=(const FString& SubStr)
 {
     this->PrivateString += SubStr.PrivateString;
     return *this;
+}
+
+FORCEINLINE FString& FString::operator+=(const TCHAR* Rhs)
+{
+	this->PrivateString += Rhs;
+	return *this;
+}
+
+FORCEINLINE TCHAR& FString::operator[](const size_t Index)
+{
+	return PrivateString[Index];
+}
+
+FORCEINLINE const TCHAR& FString::operator[](const size_t Index) const
+{
+	return PrivateString[Index];
+}
+
+FORCEINLINE const char* FString::c_char() const
+{
+#if USE_WIDECHAR
+	static std::string ConvertedStr;
+	ConvertedStr = ConvertToMultibyte(PrivateString.c_str());
+	return ConvertedStr.c_str();
+#else
+	return PrivateString.c_str();
+#endif // USE_WIDECHAR
+}
+
+inline const wchar_t* FString::c_wchar() const
+{
+#if USE_WIDECHAR
+	return PrivateString.c_str();
+#else
+	static std::wstring ConvertedStr;
+	ConvertedStr = ConvertToWideChar(PrivateString.c_str());
+	return ConvertedStr.c_str();
+#endif // USE_WIDECHAR
+}
+
+FORCEINLINE FString::ElementType& FString::Front()
+{
+	return PrivateString.front();
+}
+
+FORCEINLINE const FString::ElementType& FString::Front() const
+{
+	return PrivateString.front();
+}
+
+FORCEINLINE FString::ElementType& FString::Back()
+{
+	return PrivateString.back();
+}
+
+FORCEINLINE const FString::ElementType& FString::Back() const
+{
+	return PrivateString.back();
+}
+
+FORCEINLINE void FString::PopBack()
+{
+	PrivateString.pop_back();
+}
+
+FORCEINLINE FString::BaseStringType::iterator FString::Begin()
+{
+	return PrivateString.begin();
+}
+
+FORCEINLINE FString::BaseStringType::const_iterator FString::Begin() const
+{
+	return PrivateString.begin();
 }
 
 FORCEINLINE const FString::ElementType* FString::GetData() const

--- a/Source/Core/HAL/PlatformType.h
+++ b/Source/Core/HAL/PlatformType.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <cstdint>
 
 //~ Windows.h
@@ -22,7 +22,7 @@
 #define FORCENOINLINE __declspec(noinline)
 
 
-#define USE_WIDECHAR 0
+#define USE_WIDECHAR 1
 
 #if USE_WIDECHAR 
     #define TEXT(x) L##x

--- a/Source/Core/Rendering/UI.h
+++ b/Source/Core/Rendering/UI.h
@@ -81,7 +81,6 @@ private:
 	ImVec2 CurRatio;
 
 	TArray<FString> UUIDNames;
-	TArray<const char*> cUUIDNames;
 	TArray<uint32> UUIDs;
 	uint32 PrevSize = 0;
 	AActor* CurActor = nullptr;

--- a/Source/Core/Rendering/URenderer.cpp
+++ b/Source/Core/Rendering/URenderer.cpp
@@ -33,7 +33,7 @@ void URenderer::Create(HWND hWindow)
 	FUUIDBillBoard::Get().Create();
 
 	//LoadTexture(L"font_atlas.png");
-	LoadTexture(L"Pretendard_Kor.png");
+	LoadTexture(TEXT("Pretendard_Kor.png"));
 }
 
 void URenderer::Release()
@@ -120,9 +120,9 @@ void URenderer::Render(FRenderResourceCollection& InRenderResourceCollection)
 }
 
 
-void URenderer::LoadTexture(const wchar_t* texturePath)
+void URenderer::LoadTexture(const FString& texturePath)
 {
-	DirectX::CreateWICTextureFromFile(FDevice::Get().GetDevice(), FDevice::Get().GetDeviceContext(), texturePath, nullptr, &FontTextureSRV);
+	DirectX::CreateWICTextureFromFile(FDevice::Get().GetDevice(), FDevice::Get().GetDeviceContext(), texturePath.c_wchar(), nullptr, &FontTextureSRV);
 
 	
 	D3D11_SAMPLER_DESC samplerDesc = {};

--- a/Source/Core/Rendering/URenderer.h
+++ b/Source/Core/Rendering/URenderer.h
@@ -3,6 +3,7 @@
 #define _TCHAR_DEFINED  // TCHAR 재정의 에러 때문
 #include <d3d11.h>
 
+#include "Core/Container/String.h"
 #include "Core/Math/Vector.h"
 
 struct FVertexSimple;
@@ -60,7 +61,7 @@ public:
     /** PrimitiveComponent를 초기화 합니다. */
     // void RenderPrimitiveInternal(UPrimitiveComponent& PrimitiveComp) const;
 
-	void LoadTexture(const wchar_t* texturePath);
+	void LoadTexture(const FString& texturePath);
 	ID3D11ShaderResourceView* FontTextureSRV = nullptr;
 	ID3D11SamplerState* FontSamplerState = nullptr;
 

--- a/Source/Core/UObject/Class.cpp
+++ b/Source/Core/UObject/Class.cpp
@@ -1,11 +1,11 @@
-﻿#include "Class.h"
+#include "Class.h"
 #include <cassert>
 
 #include "Object/ObjectFactory.h"
 #include "Core/Rendering/URenderer.h"
 
 
-UClass::UClass(const char* InClassName, uint32 InClassSize, uint32 InAlignment, UClass* InSuperClass)
+UClass::UClass(const FString& InClassName, uint32 InClassSize, uint32 InAlignment, UClass* InSuperClass)
 	: ClassSize(InClassSize)
 	, ClassAlignment(InAlignment)
 	, SuperClass(InSuperClass)

--- a/Source/Core/UObject/Class.h
+++ b/Source/Core/UObject/Class.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <concepts>
 #include "Object.h"
 
@@ -9,7 +9,7 @@
 class UClass : public UObject
 {
 public:
-	UClass(const char* InClassName, uint32 InClassSize, uint32 InAlignment, UClass* InSuperClass);
+	UClass(const FString& InClassName, uint32 InClassSize, uint32 InAlignment, UClass* InSuperClass);
 	virtual ~UClass() override = default;
 
 	// 복사 & 이동 생성자 제거

--- a/Source/Core/UObject/NameTypes.cpp
+++ b/Source/Core/UObject/NameTypes.cpp
@@ -1,4 +1,4 @@
-﻿#include "NameTypes.h"
+#include "NameTypes.h"
 
 #include <atomic>
 #include <cwchar>
@@ -6,7 +6,6 @@
 #include "Core/AbstractClass/Singleton.h"
 #include "Core/Container/Map.h"
 #include "Core/Container/String.h"
-
 
 enum ENameCase : uint8
 {
@@ -50,7 +49,7 @@ struct FNameEntryId
 
 	bool operator!=(const FNameEntryId& Other) const
 	{
-		return !(*this == Other);
+		return Value != Other.Value;
 	}
 
 	explicit operator bool() const noexcept
@@ -426,11 +425,13 @@ FString FName::ToString() const
 		return {TEXT("None")};
 	}
 
-	// TODO: WIDECHAR에 대응 해야함
 	FNameEntry Entry = FNamePool::Get().Resolve(DisplayIndex);
 	return {
-		// Entry.Header.IsWide ? Entry.WideName : Entry.AnsiName
+#if USE_WIDECHAR
+		Entry.WideName
+#else
 		Entry.AnsiName
+#endif
 	};
 }
 

--- a/Source/Core/UObject/NameTypes.h
+++ b/Source/Core/UObject/NameTypes.h
@@ -1,8 +1,7 @@
-﻿#pragma once
+#pragma once
 #include "Core/HAL/PlatformType.h"
 
 class FString;
-
 
 class FName
 {

--- a/Source/Core/UObject/Object.cpp
+++ b/Source/Core/UObject/Object.cpp
@@ -1,4 +1,4 @@
-﻿#include "Core/UObject/Object.h"
+#include "Core/UObject/Object.h"
 #include "Class.h"
 
 
@@ -16,7 +16,7 @@ UClass* UObject::StaticClass()
 }
 
 UObject::UObject()
-	: NamePrivate("None")
+	: NamePrivate(FString("None"))
 	, ClassPrivate(nullptr)
 {
 }

--- a/Source/Debug/DebugConsole.cpp
+++ b/Source/Debug/DebugConsole.cpp
@@ -1,4 +1,4 @@
-﻿#include "Debug/DebugConsole.h"
+#include "Debug/DebugConsole.h"
 
 #include <cstdarg>
 #include <algorithm>
@@ -31,7 +31,7 @@ void Debug::ShowConsole(bool bWasWindowSizeUpdated, ImVec2 PreRatio, ImVec2 CurR
          ImGui::SetWindowSize(ResizeToScreen(Window->Size, PreRatio, CurRatio));
          
          for (const auto& Item : items)
-             ImGui::TextUnformatted(*Item);
+             ImGui::TextUnformatted(Item.c_char());
     
          if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
              ImGui::SetScrollHereY(1.0f);
@@ -50,7 +50,7 @@ void Debug::ShowConsole(bool bWasWindowSizeUpdated, ImVec2 PreRatio, ImVec2 CurR
     
                  FString& historyCommand = history[historyPos];
                  data->DeleteChars(0, data->BufTextLen);
-                 data->InsertChars(0, *historyCommand);
+                 data->InsertChars(0, historyCommand.c_char());
              }
              return 0;
          }))

--- a/Source/Object/Actor/Actor.cpp
+++ b/Source/Object/Actor/Actor.cpp
@@ -453,9 +453,9 @@ FVector AActor::GetActorRelativeScale() const
 	return FVector::OneVector;
 }
 
-const char* AActor::GetTypeName()
+const FString AActor::GetTypeName()
 {
-	return "Actor";
+	return TEXT("Actor");
 }
 
 bool AActor::Destroy()

--- a/Source/Object/Actor/Actor.h
+++ b/Source/Object/Actor/Actor.h
@@ -179,7 +179,7 @@ public:
 
 public:
 	bool CanEverTick() const { return bCanEverTick; }
-	virtual const char* GetTypeName();
+	virtual const FString GetTypeName();
 
 	bool Destroy();
 

--- a/Source/Object/Actor/Arrow.cpp
+++ b/Source/Object/Actor/Arrow.cpp
@@ -1,4 +1,4 @@
-﻿#include "Arrow.h"
+#include "Arrow.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 
 AArrow::AArrow()
@@ -26,7 +26,7 @@ void AArrow::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* AArrow::GetTypeName()
+const FString AArrow::GetTypeName()
 {
-	return "Arrow";
+	return TEXT("Arrow");
 }

--- a/Source/Object/Actor/Arrow.h
+++ b/Source/Object/Actor/Arrow.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Core/UObject/ObjectMacros.h"
 #include "Object/Actor/Actor.h"
 
@@ -11,6 +11,6 @@ public:
 	AArrow();
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/Cone.cpp
+++ b/Source/Object/Actor/Cone.cpp
@@ -1,4 +1,4 @@
-﻿#include "Cone.h"
+#include "Cone.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 
 
@@ -22,7 +22,7 @@ void ACone::Tick(float DeltaTime)
     Super::Tick(DeltaTime);
 }
 
-const char* ACone::GetTypeName()
+const FString ACone::GetTypeName()
 {
-    return "Cone";
+    return TEXT("Cone");
 }

--- a/Source/Object/Actor/Cone.h
+++ b/Source/Object/Actor/Cone.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Actor.h"
 
 
@@ -10,6 +10,6 @@ public:
     ACone();
     virtual void BeginPlay() override;
     virtual void Tick(float DeltaTime) override;
-    virtual const char* GetTypeName() override;
+    virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/Cube.cpp
+++ b/Source/Object/Actor/Cube.cpp
@@ -1,4 +1,4 @@
-﻿#include "Cube.h"
+#include "Cube.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 
 
@@ -22,7 +22,7 @@ void ACube::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* ACube::GetTypeName()
+const FString ACube::GetTypeName()
 {
-	return "Cube";
+	return TEXT("Cube");
 }

--- a/Source/Object/Actor/Cube.h
+++ b/Source/Object/Actor/Cube.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Actor.h"
 
 
@@ -10,6 +10,6 @@ public:
 	ACube();
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/Cylinder.cpp
+++ b/Source/Object/Actor/Cylinder.cpp
@@ -89,7 +89,7 @@ void ACylinder::Tick(float DeltaTime)
 	SetActorTransform(NewTransform);
 }
 
-const char* ACylinder::GetTypeName()
+const FString ACylinder::GetTypeName()
 {
-    return "Cylinder";
+    return TEXT("Cylinder");
 }

--- a/Source/Object/Actor/Cylinder.h
+++ b/Source/Object/Actor/Cylinder.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Actor.h"
 
 
@@ -10,6 +10,6 @@ public:
     ACylinder();
     virtual void BeginPlay() override;
     virtual void Tick(float DeltaTime) override;
-    virtual const char* GetTypeName() override;
+    virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/Quad.cpp
+++ b/Source/Object/Actor/Quad.cpp
@@ -21,7 +21,7 @@ void AQuad::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* AQuad::GetTypeName()
+const FString AQuad::GetTypeName()
 {
-	return "Cube";
+	return TEXT("Cube");
 }

--- a/Source/Object/Actor/Quad.h
+++ b/Source/Object/Actor/Quad.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Actor.h"
 
 
@@ -10,6 +10,6 @@ public:
 	AQuad();
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/Sphere.cpp
+++ b/Source/Object/Actor/Sphere.cpp
@@ -1,4 +1,4 @@
-﻿#include "Sphere.h"
+#include "Sphere.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 
 
@@ -22,7 +22,7 @@ void ASphere::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* ASphere::GetTypeName()
+const FString ASphere::GetTypeName()
 {
-	return "Sphere";
+	return TEXT("Sphere");
 }

--- a/Source/Object/Actor/Sphere.h
+++ b/Source/Object/Actor/Sphere.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Object/Actor/Actor.h"
 
 
@@ -10,6 +10,6 @@ public:
 	ASphere();
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Actor/SpotLight.cpp
+++ b/Source/Object/Actor/SpotLight.cpp
@@ -21,7 +21,7 @@ void ASpotLight::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* ASpotLight::GetTypeName()
+const FString ASpotLight::GetTypeName()
 {
-	return "SpotLight";
+	return TEXT("SpotLight");
 }

--- a/Source/Object/Actor/SpotLight.h
+++ b/Source/Object/Actor/SpotLight.h
@@ -10,6 +10,6 @@ public:
 	virtual ~ASpotLight() = default;
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 };
 

--- a/Source/Object/Assets/AssetManager.cpp
+++ b/Source/Object/Assets/AssetManager.cpp
@@ -62,7 +62,7 @@ void UAssetManager::LoadAssets()
 			}
 			else
 			{
-				cout << "Scene Asset Load Failed: " << asset.Value.GetAssetName().GetData() << endl;
+				cout << "Scene Asset Load Failed: " << asset.Value.GetAssetName().c_char() << endl;
 			}
 			break;
 		}

--- a/Source/Object/Assets/SceneAsset.cpp
+++ b/Source/Object/Assets/SceneAsset.cpp
@@ -17,11 +17,11 @@ bool USceneAsset::Load()
 {
 	if (IsLoaded())
 	{
-		cout << "Asset already loaded: " << MetaData.GetAssetPath().GetData() << '\n';
+		cout << "Asset already loaded: " << MetaData.GetAssetPath().c_char() << '\n';
 		return true;
 	}
 
-	filesystem::path filePath = MetaData.GetAssetPath().GetData();
+	filesystem::path filePath = MetaData.GetAssetPath().c_char();
 	if (filesystem::exists(filePath) == false)
 	{
 		cout << "File not found: " << filePath << '\n';
@@ -119,9 +119,9 @@ bool USceneAsset::Save(FString path)
 		}
 		primitiveData["Scale"] = scale;
 
-		primitives.append(primitive.Key.GetData(), primitiveData);
+		primitives.append(primitive.Key.c_char(), primitiveData);
 
-		primitiveData["Type"] = primitive.Value.Type.GetData();
+		primitiveData["Type"] = primitive.Value.Type.c_char();
 	}
 
 	sceneData["Primitives"] = primitives;
@@ -134,10 +134,10 @@ bool USceneAsset::Save(FString path)
 		path = MetaData.GetAssetPath();
 	}
 
-	ofstream file(path.GetData());
+	ofstream file(path.c_char());
 	if (!file.is_open())
 	{
-		cout << "File open failed: " << path.GetData() << '\n';
+		cout << "File open failed: " << path.c_char() << '\n';
 		return false;
 	}
 

--- a/Source/Object/Gizmo/Axis.cpp
+++ b/Source/Object/Gizmo/Axis.cpp
@@ -62,7 +62,7 @@ void AAxis::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-const char* AAxis::GetTypeName()
+const FString AAxis::GetTypeName()
 {
-	return "Axis";
+	return TEXT("Axis");
 }

--- a/Source/Object/Gizmo/Axis.h
+++ b/Source/Object/Gizmo/Axis.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Core/Interfaces/GizmoInterface.h"
 #include "Object/Actor/Actor.h"
 
@@ -13,7 +13,7 @@ public:
 
 	virtual void BeginPlay() override;
 	virtual void Tick(float DeltaTime) override;
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 
 	//~ Begin IGizmoInterface
 	virtual bool IsGizmo() override { return true; }

--- a/Source/Object/Gizmo/GizmoHandle.cpp
+++ b/Source/Object/Gizmo/GizmoHandle.cpp
@@ -152,9 +152,9 @@ void AGizmoHandle::SetActive(bool bActive)
 	}*/
 }
 
-const char* AGizmoHandle::GetTypeName()
+const FString AGizmoHandle::GetTypeName()
 {
-	return "GizmoHandle";
+	return TEXT("GizmoHandle");
 }
 
 void AGizmoHandle::DoTransform(FTransform& AT, FVector Result, AActor* Actor )

--- a/Source/Object/Gizmo/GizmoHandle.h
+++ b/Source/Object/Gizmo/GizmoHandle.h
@@ -32,7 +32,7 @@ public:
 	ESelectedAxis SelectedAxis = ESelectedAxis::None;
 	EGizmoType GizmoType = EGizmoType::Translate;
 
-	virtual const char* GetTypeName() override;
+	virtual const FString GetTypeName() override;
 
 private:
 	void DoTransform(FTransform& AT, FVector Result, AActor* Actor);

--- a/Source/Object/World/World.cpp
+++ b/Source/Object/World/World.cpp
@@ -30,7 +30,6 @@
 
 void UWorld::InitWorld()
 {
-	//TODO : 
 	GridSize = FString::ToFloat(UConfigManager::Get().GetValue(TEXT("World"), TEXT("GridSize")));
 }
 
@@ -410,7 +409,7 @@ UWorldInfo UWorld::GetWorldInfo() const
 {
 	UWorldInfo WorldInfo;
 	WorldInfo.ActorCount = Actors.Num();
-	WorldInfo.SceneName = *SceneName;
+	WorldInfo.SceneName = std::string(SceneName.c_char());
 	WorldInfo.Version = 1;
 	uint32 i = 0;
 	for (auto& actor : Actors)
@@ -426,7 +425,7 @@ UWorldInfo UWorld::GetWorldInfo() const
 				.Location = actor->GetActorPosition(),
 				.Rotation = actor->GetActorRotation(),
 				.Scale = actor->GetActorScale(),
-				.ObjectType = actor->GetTypeName(),
+				.ObjectType = actor->GetTypeName().c_char(),
 				.UUID = actor->GetUUID()
 			}
 		));

--- a/Source/Resource/DirectResource/PixelShader.cpp
+++ b/Source/Resource/DirectResource/PixelShader.cpp
@@ -37,6 +37,6 @@ void FPixelShader::ShaderLoad(const LPCWSTR& _Path, const FString& _EntryPoint, 
 	
 	SetShaderType(ShaderType::Pixel);
 	
-	HRESULT hr = D3DCompileFromFile(_Path, nullptr, nullptr, *_EntryPoint, "ps_5_0", shaderFlags, 0, &BinaryCode, &Error);
+	HRESULT hr = D3DCompileFromFile(_Path, nullptr, nullptr, _EntryPoint.c_char(), "ps_5_0", shaderFlags, 0, &BinaryCode, &Error);
 	FDevice::Get().GetDevice()->CreatePixelShader(BinaryCode->GetBufferPointer(), BinaryCode->GetBufferSize(), nullptr, &ShaderPtr);
 }

--- a/Source/Resource/DirectResource/VertexShader.cpp
+++ b/Source/Resource/DirectResource/VertexShader.cpp
@@ -40,7 +40,7 @@ void FVertexShader::ShaderLoad(const LPCWSTR& _Path, const FString& _EntryPoint,
 
 	SetShaderType(ShaderType::Vertex);
 	
-	D3DCompileFromFile(_Path, nullptr, nullptr, *_EntryPoint, "vs_5_0", shaderFlags, 0, &BinaryCode, &Error);
+	D3DCompileFromFile(_Path, nullptr, nullptr, _EntryPoint.c_char(), "vs_5_0", shaderFlags, 0, &BinaryCode, &Error);
 	FDevice::Get().GetDevice()->CreateVertexShader(BinaryCode->GetBufferPointer(), BinaryCode->GetBufferSize(), nullptr, &ShaderPtr);
 
 }

--- a/Source/Resource/Texture.cpp
+++ b/Source/Resource/Texture.cpp
@@ -161,7 +161,7 @@ void FTexture::CreateDepthStencilView()
 void FTexture::ResLoad(const FString& InPath)
 
 {
-	std::string str = *InPath;
+	std::string str = InPath.c_char();
 
 	std::wstring wstr(str.begin(), str.end());
 

--- a/main.cpp
+++ b/main.cpp
@@ -95,17 +95,17 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 	UConfigManager::Get().LoadConfig("editor.ini");
 
 	FString AppName = UConfigManager::Get().GetValue(TEXT("General"), TEXT("AppName"));
-	uint32 ScreenWidth = std::stoi((UConfigManager::Get().GetValue(TEXT("Display"), TEXT("Width"))).GetData());
-	uint32 ScreenHeight = std::stoi((UConfigManager::Get().GetValue(TEXT("Display"), TEXT("Height"))).GetData());
+	uint32 ScreenWidth = std::stoi((UConfigManager::Get().GetValue(TEXT("Display"), TEXT("Width"))).c_char());
+	uint32 ScreenHeight = std::stoi((UConfigManager::Get().GetValue(TEXT("Display"), TEXT("Height"))).c_char());
 
 	UEngine& Engine = UEngine::Get();
 	if (UConfigManager::Get().GetValue(TEXT("Display"), TEXT("Fullscreen")) == "true")
 	{
-		Engine.Initialize(hInstance, AppName.ToWideString().c_str(), L"JungleWindow", 1920, 1080, EScreenMode::Fullscreen);
+		Engine.Initialize(hInstance, AppName.c_wchar(), TEXT("JungleWindow"), 1920, 1080, EScreenMode::Fullscreen);
 	}
 	else
 	{
-		Engine.Initialize(hInstance, AppName.ToWideString().c_str(), L"JungleWindow", 1920, 1080);
+		Engine.Initialize(hInstance, AppName.c_wchar(), TEXT("JungleWindow"), 1920, 1080);
 	}
 
 	Engine.Run();


### PR DESCRIPTION
fix: set wchar_t as default type

기본 문자열 사용시 TEXT("Some Text.")의 형태로 TEXT 매크로를 사용 바람.
std::string 대신 FString을 사용하길 바람.
출력시 AnsiName을 얻기 위하여 SomeFString.c_char()을 사용하길 바람.